### PR TITLE
Restore AsDirPath

### DIFF
--- a/ymdflag.go
+++ b/ymdflag.go
@@ -101,6 +101,12 @@ func ValidateYMD(yyyymmdd int) error {
 
 // AsDirPath returns the YMDFlag as `"YYYY/MM/DD"` using given path seperator
 // If the YMDFlag is nil, then an empty string is returned.
+func (ymd YMDFlag) AsDirPath() string {
+	return FormatDirPath(ymd, '/')
+}
+
+// FormatDirPath returns the YMDFlag as `"YYYY{separator}MM{separator}DD"` using given path seperator
+// If the YMDFlag is nil, then an empty string is returned.
 func FormatDirPath(ymd YMDFlag, separator rune) string {
 	if ymd.IsZero() {
 		return ""

--- a/ymdflag_test.go
+++ b/ymdflag_test.go
@@ -112,3 +112,11 @@ func TestStringToYMD(t *testing.T) {
 	assert.NoError(t, err, "empty string should not return an error")
 	assert.Equal(t, 0, yyyymmdd)
 }
+
+func TestAsDirPath(t *testing.T) {
+
+	flag := NewYMDFlag(time.Date(2022, 1, 2, 3, 4, 5, 6, time.UTC))
+	path := flag.AsDirPath()
+
+	assert.Equal(t, "2022/01/02", path)
+}


### PR DESCRIPTION
It seems like `AsDirPath` was removed and replaced with `FormatDirPath(date, seperator)` this broke the interface. Not sure if it was intended.